### PR TITLE
Fixes for Windows build

### DIFF
--- a/wmpis.sh
+++ b/wmpis.sh
@@ -88,7 +88,7 @@ if [ ! -d Ipopt-3.11.7 ]; then
     mkdir build
     cd build
     # start building
-    ../configure --enable-static --prefix $PSOPT_BUILD_DIR/.target -with-blas="-L$PSOPT_BUILD_DIR/.target/lib -llibopenblas"
+    ../configure --enable-static --prefix $PSOPT_BUILD_DIR/.target -with-blas="-L$PSOPT_BUILD_DIR/.target/lib -lopenblas"
     make
     cd ../..
 fi
@@ -205,11 +205,11 @@ cd ..
 unzip ../../.download/patch_3.02.zip
 cp patch_3.02/psopt.cxx PSOPT/src/
 # Apply local patches
-patch -p1 < ../../psopt-installer-master/patches/psopt-gnuplot-windows.patch
-patch -p1 < ../../psopt-installer-master/patches/psopt-c++0x-windows.patch
-patch -p1 < ../../psopt-installer-master/patches/psopt-lambdafunction-windows.patch
-patch -p1 < ../../psopt-installer-master/patches/psopt-bugfix-static-variable.patch
-patch -p1 < ../../psopt-installer-master/patches/psopt-ipopt-3-11-7-compatibility.patch
+patch -p1 < $PSOPT_BUILD_DIR/patches/psopt-gnuplot-windows.patch
+patch -p1 < $PSOPT_BUILD_DIR/patches/psopt-c++0x-windows.patch
+patch -p1 < $PSOPT_BUILD_DIR/patches/psopt-lambdafunction-windows.patch
+patch -p1 < $PSOPT_BUILD_DIR/patches/psopt-bugfix-static-variable.patch
+patch -p1 < $PSOPT_BUILD_DIR/patches/psopt-ipopt-3-11-7-compatibility.patch
 # PSOPT static library
 sed -i -n 'H;${x;s#/usr/bin/##g;p;}' PSOPT/lib/Makefile
 sed -i -n 'H;${x;s#-I$(DMATRIXDIR)/include#-U WIN32#g;p;}' PSOPT/lib/Makefile
@@ -336,7 +336,7 @@ cd .packages
 unzip ../.download/modern-psopt-interface.zip
 cd modern-psopt-interface-master
 make PSOPT=../..
-make install PREFIX=../../.target
+make install PSOPT=../.. PREFIX=../../.target
 cd ../..
 # Modern Obstacle Example
 echo ""


### PR DESCRIPTION
- Replace ../../psopt-installer-master with actual location of patches in $PSOPT_BUILD_DIR
- Add PSOPT=../.. to final make install invocation, so Makefile_include.mk can be successfully located
- Use -lopenblas instead of -llibopenblas, ~~the former works on both MinGW and Cygwin while the latter only works on MinGW~~ (nevermind, can probably be left out, see line comment at L91)
