### PR TITLE
Modifications for Ubuntu

### DIFF
--- a/uppis.sh
+++ b/uppis.sh
@@ -86,7 +86,7 @@ mv IpTripletToCSRConverter.cpp Ipopt/src/Algorithm/LinearSolvers/IpTripletToCSRC
 mkdir -p build
 cd build
 # start building
-../configure --enable-static --prefix ~/Ipopt-3.9.3
+../configure --enable-static --prefix ~/Ipopt-3.9.3 LDFLAGS="-Wl,--no-as-needed" ac_cv_have_decl_drand48=yes ac_cv_have_decl_rand=yes ac_cv_have_decl_srand=yes COIN_SKIP_PROJECTS=ASL
 make install
 cd ../../..
 # Adol-C
@@ -146,6 +146,16 @@ sed -n 'H;${x;s/ADOLC_LIBS    = -ladolc/ADOLC_LIBS    = $(USERHOME)\/adolc_base\
 mv temp_file PSOPT/examples/Makefile_linux.inc
 sed -n 'H;${x;s/libcoinhsl.a/&  $(IPOPTLIBDIR)\/ThirdParty\/libcoinmumps.a $(IPOPTLIBDIR)\/ThirdParty\/libcoinmetis.a -lpthread -lgfortran $(IPOPTLIBDIR)\/ThirdParty\/libcoinblas.a $(IPOPTLIBDIR)\/ThirdParty\/libcoinlapack.a -latlas -lf77blas/;p;}' PSOPT/examples/Makefile_linux.inc > temp_file
 mv temp_file PSOPT/examples/Makefile_linux.inc
+if ! test "x$CXX" = "x"; then
+  sed -i 's/CXX           =/#/' dmatrix/lib/Makefile
+  sed -i 's/CXX           =/#/' dmatrix/examples/Makefile
+  sed -i 's/CXX           =/#/' PSOPT/lib/Makefile
+  sed -i 's/CXX           =/#/' PSOPT/examples/Makefile_linux.inc
+fi
+for i in `ls lusol/csrc/*.h`; do
+  chmod +w $i
+  echo "" >> $i
+done
 # Psopt Compilation
 make all
 echo "installation finished"


### PR DESCRIPTION
Add -p to mkdir so it doesn't cause an error if the directories already exist (e.g. calling script the second time)

Comment a mv line in get.Metis that doesn't apply after the sed changes to version number, and would otherwise be an error

Add || true to a few lines that seem to always fail, the recursive wget for ampl and the make of gnuplot

Remove existing ampl solvers directory if it's in the way

Fix filename, skip building tutorial for gnuplot

Add flags to Ipopt configure and modify some Makefiles and headers to allow optionally building with a different compiler (specifically I'm trying clang) by exporting CXX=...